### PR TITLE
Refactor History ( Based on Meeting Conversation )

### DIFF
--- a/src/Repository/uBeac.Core.Repositories.History.Abstractions/IHistoryRepository.cs
+++ b/src/Repository/uBeac.Core.Repositories.History.Abstractions/IHistoryRepository.cs
@@ -2,5 +2,5 @@
 
 public interface IHistoryRepository : IRepository
 {
-    Task AddToHistory(object data, string actionName = "None", IApplicationContext context = null, CancellationToken cancellationToken = default);
+    Task Add(object data, string actionName = "None", IApplicationContext context = null, CancellationToken cancellationToken = default);
 }

--- a/src/Repository/uBeac.Core.Repositories.History.Extensions/History.cs
+++ b/src/Repository/uBeac.Core.Repositories.History.Extensions/History.cs
@@ -2,14 +2,14 @@
 
 public static class History
 {
-    public static async Task AddToHistory(object data, string actionName = "None", IApplicationContext context = null, CancellationToken cancellationToken = default)
+    public static async Task Add(object data, string actionName = "None", IApplicationContext context = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         var dataType = data.GetType();
 
         var repositories = GetRepositories(dataType);
-        var tasks = repositories.Select(_ => _.AddToHistory(data, actionName, context, cancellationToken));
+        var tasks = repositories.Select(_ => _.Add(data, actionName, context, cancellationToken));
         await Task.WhenAll(tasks);
     }
 

--- a/src/Repository/uBeac.Core.Repositories.History.MongoDB/Repository.cs
+++ b/src/Repository/uBeac.Core.Repositories.History.MongoDB/Repository.cs
@@ -18,7 +18,7 @@ public class MongoHistoryRepository<TKey, THistory, TContext> : IHistoryReposito
         MongoDbContext = mongoDbContext;
     }
 
-    protected virtual string GetCollectionName(Type dataType) => $"{dataType.Name}.History";
+    protected virtual string GetCollectionName(Type dataType) => $"{dataType.Name}_History";
 
     protected virtual async Task Insert(THistory history, CancellationToken cancellationToken = default)
     {

--- a/src/Repository/uBeac.Core.Repositories.History.MongoDB/Repository.cs
+++ b/src/Repository/uBeac.Core.Repositories.History.MongoDB/Repository.cs
@@ -33,7 +33,7 @@ public class MongoHistoryRepository<TKey, THistory, TContext> : IHistoryReposito
         await collection.InsertOneAsync(bsonDocument, new InsertOneOptions(), cancellationToken);
     }
 
-    public async Task AddToHistory(object data, string actionName = "None", IApplicationContext context = null, CancellationToken cancellationToken = default)
+    public async Task Add(object data, string actionName = "None", IApplicationContext context = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Repository/uBeac.Core.Repositories.MongoDB/Repository.cs
+++ b/src/Repository/uBeac.Core.Repositories.MongoDB/Repository.cs
@@ -5,9 +5,9 @@ using System.Linq.Expressions;
 namespace uBeac.Repositories.MongoDB;
 
 public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<TKey, TEntity>
-        where TKey : IEquatable<TKey>
-        where TEntity : IEntity<TKey>
-        where TContext : IMongoDBContext
+    where TKey : IEquatable<TKey>
+    where TEntity : IEntity<TKey>
+    where TContext : IMongoDBContext
 {
     protected readonly IMongoCollection<TEntity> Collection;
     protected readonly IMongoCollection<BsonDocument> BsonCollection;
@@ -29,6 +29,15 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
         return typeof(TEntity).Name;
     }
 
+    protected virtual async Task AddToHistory(TEntity entity, string actionName, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var context = AppContext;
+        if (entity is IAuditEntity<TKey> audit) context = audit.Context;
+        await History.Add(entity, actionName, context, cancellationToken);
+    }
+
     public virtual async Task<bool> Delete(TKey id, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -36,7 +45,7 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
         var idFilter = Builders<TEntity>.Filter.Eq(doc => doc.Id, id);
         var entity = await Collection.FindOneAndDeleteAsync(idFilter, null, cancellationToken);
 
-        await History.Add(entity, nameof(Delete), AppContext, cancellationToken);
+        await AddToHistory(entity, nameof(Delete), cancellationToken);
 
         return entity != null;
     }
@@ -78,7 +87,7 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
 
         await Collection.InsertOneAsync(entity, null, cancellationToken);
 
-        await History.Add(entity, nameof(Create), AppContext, cancellationToken);
+        await AddToHistory(entity, nameof(Create), cancellationToken);
     }
 
     public virtual async Task<TEntity> Update(TEntity entity, CancellationToken cancellationToken = default)
@@ -91,7 +100,7 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
         var idFilter = Builders<TEntity>.Filter.Eq(x => x.Id, entity.Id);
         entity = await Collection.FindOneAndReplaceAsync(idFilter, entity, null, cancellationToken);
 
-        await History.Add(entity, nameof(Update), AppContext, cancellationToken);
+        await AddToHistory(entity, nameof(Update), cancellationToken);
 
         return entity;
     }

--- a/src/Repository/uBeac.Core.Repositories.MongoDB/Repository.cs
+++ b/src/Repository/uBeac.Core.Repositories.MongoDB/Repository.cs
@@ -36,7 +36,7 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
         var idFilter = Builders<TEntity>.Filter.Eq(doc => doc.Id, id);
         var entity = await Collection.FindOneAndDeleteAsync(idFilter, null, cancellationToken);
 
-        await History.AddToHistory(entity, nameof(Delete), AppContext, cancellationToken);
+        await History.Add(entity, nameof(Delete), AppContext, cancellationToken);
 
         return entity != null;
     }
@@ -78,7 +78,7 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
 
         await Collection.InsertOneAsync(entity, null, cancellationToken);
 
-        await History.AddToHistory(entity, nameof(Create), AppContext, cancellationToken);
+        await History.Add(entity, nameof(Create), AppContext, cancellationToken);
     }
 
     public virtual async Task<TEntity> Update(TEntity entity, CancellationToken cancellationToken = default)
@@ -91,7 +91,7 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
         var idFilter = Builders<TEntity>.Filter.Eq(x => x.Id, entity.Id);
         entity = await Collection.FindOneAndReplaceAsync(idFilter, entity, null, cancellationToken);
 
-        await History.AddToHistory(entity, nameof(Update), AppContext, cancellationToken);
+        await History.Add(entity, nameof(Update), AppContext, cancellationToken);
 
         return entity;
     }


### PR DESCRIPTION
**Changes:**
- Change name of `AddToHistory()` methods to `Add()`
Before: `History.AddToHistory(data, actionName, etc.)`
Now: `History.Add(data, actionName, etc.)`
- Use from context property of audit entity when adding to history
- Modify history collection names to prevent the occurrence of the problem
Before: `Entity.History`
Now: `Entity_History`