### PR TITLE
Add Entity Options to Repository

### DIFF
--- a/src/Identity/uBeac.Core.Identity/Stores/RoleStore.cs
+++ b/src/Identity/uBeac.Core.Identity/Stores/RoleStore.cs
@@ -23,21 +23,21 @@ namespace uBeac.Identity
         public async Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _repository.Create(role, cancellationToken);
+            await _repository.Create(role, cancellationToken: cancellationToken);
             return IdentityResult.Success;
         }
 
         public async Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _repository.Update(role, cancellationToken);
+            await _repository.Update(role, cancellationToken: cancellationToken);
             return IdentityResult.Success;
         }
 
         public async Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _repository.Delete(role.Id, cancellationToken);
+            await _repository.Delete(role.Id, cancellationToken: cancellationToken);
             return IdentityResult.Success;
         }
 

--- a/src/Identity/uBeac.Core.Identity/Stores/UserStore_IUserLoginStore.cs
+++ b/src/Identity/uBeac.Core.Identity/Stores/UserStore_IUserLoginStore.cs
@@ -39,14 +39,14 @@ namespace uBeac.Identity
         public async Task<IdentityResult> CreateAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _repository.Create(user, cancellationToken);
+            await _repository.Create(user, cancellationToken: cancellationToken);
             return IdentityResult.Success;
         }
 
         public async Task<IdentityResult> DeleteAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _repository.Delete(user.Id, cancellationToken);
+            await _repository.Delete(user.Id, cancellationToken: cancellationToken);
             return IdentityResult.Success;
         }
 
@@ -67,7 +67,7 @@ namespace uBeac.Identity
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            await _repository.Update(user, cancellationToken);
+            await _repository.Update(user, cancellationToken: cancellationToken);
 
             return IdentityResult.Success;
         }

--- a/src/Repository/uBeac.Core.Repositories.Abstractions/IEntityRepository.cs
+++ b/src/Repository/uBeac.Core.Repositories.Abstractions/IEntityRepository.cs
@@ -10,9 +10,9 @@ namespace uBeac.Repositories
         where TKey : IEquatable<TKey>
         where TEntity : IEntity<TKey>
     {
-        Task Create(TEntity entity, CancellationToken cancellationToken = default);
-        Task<TEntity> Update(TEntity entity, CancellationToken cancellationToken = default);
-        Task<bool> Delete(TKey id, CancellationToken cancellationToken = default);
+        Task Create(TEntity entity, CreateEntityOptions? options = null, CancellationToken cancellationToken = default);
+        Task<TEntity> Update(TEntity entity, UpdateEntityOptions? options = null, CancellationToken cancellationToken = default);
+        Task<bool> Delete(TKey id, DeleteEntityOptions? options = null, CancellationToken cancellationToken = default);
         Task<IEnumerable<TEntity>> GetAll(CancellationToken cancellationToken = default);
         Task<TEntity> GetById(TKey id, CancellationToken cancellationToken = default);
         Task<IEnumerable<TEntity>> GetByIds(IEnumerable<TKey> ids, CancellationToken cancellationToken = default);

--- a/src/Repository/uBeac.Core.Repositories.Abstractions/Options.cs
+++ b/src/Repository/uBeac.Core.Repositories.Abstractions/Options.cs
@@ -1,0 +1,16 @@
+﻿namespace uBeac.Repositories;
+
+public class CreateEntityOptions
+{
+    public string? ActionName { get; set; }
+}
+
+public class UpdateEntityOptions
+{
+    public string? ActionName { get; set; }
+}
+
+public class DeleteEntityOptions
+{
+    public string? ActionName { get; set; }
+}

--- a/src/Repository/uBeac.Core.Repositories.MongoDB/Repository.cs
+++ b/src/Repository/uBeac.Core.Repositories.MongoDB/Repository.cs
@@ -38,14 +38,14 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
         await History.Add(entity, actionName, context, cancellationToken);
     }
 
-    public virtual async Task<bool> Delete(TKey id, CancellationToken cancellationToken = default)
+    public virtual async Task<bool> Delete(TKey id, DeleteEntityOptions? options = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         var idFilter = Builders<TEntity>.Filter.Eq(doc => doc.Id, id);
         var entity = await Collection.FindOneAndDeleteAsync(idFilter, null, cancellationToken);
 
-        await AddToHistory(entity, nameof(Delete), cancellationToken);
+        await AddToHistory(entity, options?.ActionName ?? nameof(Delete), cancellationToken);
 
         return entity != null;
     }
@@ -78,7 +78,7 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
         return await findResult.ToListAsync(cancellationToken);
     }
 
-    public virtual async Task Create(TEntity entity, CancellationToken cancellationToken = default)
+    public virtual async Task Create(TEntity entity, CreateEntityOptions? options = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -87,10 +87,10 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
 
         await Collection.InsertOneAsync(entity, null, cancellationToken);
 
-        await AddToHistory(entity, nameof(Create), cancellationToken);
+        await AddToHistory(entity, options?.ActionName ?? nameof(Create), cancellationToken);
     }
 
-    public virtual async Task<TEntity> Update(TEntity entity, CancellationToken cancellationToken = default)
+    public virtual async Task<TEntity> Update(TEntity entity, UpdateEntityOptions? options = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -100,7 +100,7 @@ public class MongoEntityRepository<TKey, TEntity, TContext> : IEntityRepository<
         var idFilter = Builders<TEntity>.Filter.Eq(x => x.Id, entity.Id);
         entity = await Collection.FindOneAndReplaceAsync(idFilter, entity, null, cancellationToken);
 
-        await AddToHistory(entity, nameof(Update), cancellationToken);
+        await AddToHistory(entity, options?.ActionName ?? nameof(Update), cancellationToken);
 
         return entity;
     }

--- a/src/Service/uBeac.Core.Services/EntityService.cs
+++ b/src/Service/uBeac.Core.Services/EntityService.cs
@@ -19,7 +19,7 @@ namespace uBeac.Services
         {
             cancellationToken.ThrowIfCancellationRequested();
             
-            return await Repository.Delete(id, cancellationToken);
+            return await Repository.Delete(id, cancellationToken: cancellationToken);
         }
 
         public virtual async Task<IEnumerable<TEntity>> GetAll(CancellationToken cancellationToken = default)
@@ -46,13 +46,13 @@ namespace uBeac.Services
         public virtual async Task Create(TEntity entity, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await Repository.Create(entity, cancellationToken);
+            await Repository.Create(entity, cancellationToken: cancellationToken);
         }
 
         public virtual async Task<TEntity> Update(TEntity entity, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return await Repository.Update(entity, cancellationToken);
+            return await Repository.Update(entity, cancellationToken: cancellationToken);
         }
     }
 


### PR DESCRIPTION
**Issue:**
We needed to change the action names when calling create, update and delete methods of repository.
For example, in the Enable() method, we call the Update() method, but action name is Update instead of Enable.

**Solution:**
Add entity options to Create(), Update() and Delete() methods of repository that we can change the value of the action name.
```cs
await Update(entity, new UpdateEntityOptions { ActionName = nameof(Enable) }, cancellationToken);
```
Default value of options is null.
```cs
await Update(entity, cancellationToken: cancellationToken);
```